### PR TITLE
Update desktop capture

### DIFF
--- a/javascripts/bg.js
+++ b/javascripts/bg.js
@@ -41,7 +41,7 @@ function grabFrame(ctx, video, stream) {
   var url = canvas.toDataURL("png", null);
   console.log('captured', url.length, 'bytes,', canvas.width+'x'+canvas.height);
   ctx.imageData = [url];
-  stream.stop();
+  stream.getVideoTracks()[0].stop();
   video.src = "";
   newTab(ctx);
 }
@@ -81,7 +81,7 @@ function showNotification(ctx, stream) {
       if (doCapture) {
         attachToVideo(ctx, stream);
       } else {
-        stream.stop();
+        stream.getVideoTracks()[0].stop();
       }
     }
   };


### PR DESCRIPTION
This may fix [issue #6](https://github.com/rojer/a-s-minus/issues/6). The plugin uses MediaStream.stop() to stop capturing the desktop. That method is [deprecated as of Chrome 45](https://developers.google.com/web/updates/2015/07/mediastream-deprecations?hl=en#stop-ended-and-active). The update uses the suggested method to end desktop capture.

I tried capture desktop on the latest version of a-s-minus. It didn't fail. It was failing on a fork that I am using though. I can't explain why that is so, but this update fixed it.
