### PR TITLE
Disable automatically sharing screenshots to the public in Google Search results.

### DIFF
--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -1497,7 +1497,7 @@ SavePage.setPublicGdrive = function(fileId, authToken) {
   setPermissionsRequest.open("POST", "https://www.googleapis.com/drive/v2/files/" + fileId + "/permissions");
   setPermissionsRequest.setRequestHeader("Authorization", "OAuth " + authToken);
   setPermissionsRequest.setRequestHeader("Content-Type", "application/json");
-  setPermissionsRequest.send(JSON.stringify({ role: "reader", type: "anyone" }));
+  setPermissionsRequest.send(JSON.stringify({ role: "reader", type: "anyone", withLink: true }));
 };
 
 /**


### PR DESCRIPTION
Howdy,

  Love what you've done with this extension, nice work!

  I didn't like that my screenshots that I saved to my Google Drive were uploaded with permissions that allowed them to be searchable by the general public in a Google Search, so here's a trivial patch that sets the proper default "withLink" permission to make it so that new screenshot files saved to Google Drive are set with the "Readable by anyone with the link" permission and not "Public on the web" (shows up in google search results) permission.

References:
https://developers.google.com/drive/v2/reference/permissions
http://stackoverflow.com/questions/12386416/google-drive-sdk-update-sharing-permissions

NOTE: in the v3 drive API this is done with the "allowFileDiscovery" boolean instead of "withLink": https://developers.google.com/drive/v3/reference/permissions

Regards,

-Thor J. Kooda
