### PR TITLE
Feature to remember selected GDrive folder

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -121,6 +121,9 @@
                     <br />
                     <!-- Folder select -->
                     <select id="gdrive-folder-select"></select>
+					          <br />
+					          <input type="checkbox" id="save-gdrive-folder-pref"><label for="gdrive-folder-pref">Remember this folder?</label>
+                    <br />
                     <br />
                     <span id="gdrive-save-button" class="button save">Save</span>
                   </div>
@@ -130,6 +133,9 @@
                     <input type="checkbox" id="gdrive-short-link"><label for="gdrive-short-link">Short link</label>
                   </div>
                   <div id="gdrive-user">
+                    <br />
+                    <br />
+                    <br />
                     <p>Account: <span></span></p>
                   </div>
                   <div id="notice">

--- a/javascripts/bg.js
+++ b/javascripts/bg.js
@@ -105,7 +105,7 @@ function captureDesktop(ctx) {
       function(streamId) {
         if (!streamId) return;  // User canceled.
         navigator.webkitGetUserMedia(
-            { audio: false, 
+            { audio: false,
               video: {
                 mandatory: {
                   chromeMediaSource: 'desktop',
@@ -195,6 +195,11 @@ localStorage.format || (localStorage.format = "png");
 localStorage.delay_sec || (localStorage.delay_sec = 3);
 localStorage.tip_touch_shown || (localStorage.tip_touch_shown = 0);
 
+// Set the default value for GDrive folder remembering
+localStorage.folderPref ||
+localStorage.setItem("folderPref",
+  JSON.stringify({remember: false, data: {}}));
+
 // Clean up old junk from localStorage.
 localStorage.removeItem("data-tracking");
 localStorage.removeItem("autoSave");
@@ -227,7 +232,7 @@ function handleRequest(ctx, req, sender) {
     testImage.src = "";
     setContextForTab([ctx.windowId, ctx.tabId], null);  // Disconnect from original tab.
   };
-  
+
   switch (req.action){
     case "visible": {
       if ("selected" == ctx.userAction) {

--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -97,9 +97,9 @@ function prepareEditArea(req) {
         imageHeight = editH;
         showCtx.drawImage(
             this,
-            centerOffX * getDevicePixelRatio(), 
-            centerOffY * getDevicePixelRatio(), 
-            imageWidth * getDevicePixelRatio(), 
+            centerOffX * getDevicePixelRatio(),
+            centerOffY * getDevicePixelRatio(),
+            imageWidth * getDevicePixelRatio(),
             imageHeight * getDevicePixelRatio(),
             0, 0,
             imageWidth, imageHeight
@@ -127,8 +127,8 @@ function prepareEditArea(req) {
         } else {
           editW = imageWidth / getDevicePixelRatio();
         }
-        editH = lastH ? 
-                    (imageHeight / getDevicePixelRatio()) * (numTilesY - 1) + (lastH / getDevicePixelRatio()) : 
+        editH = lastH ?
+                    (imageHeight / getDevicePixelRatio()) * (numTilesY - 1) + (lastH / getDevicePixelRatio()) :
                     (imageHeight / getDevicePixelRatio()) * (numTilesY - 1);
         updateEditArea();
         updateShowCanvas();
@@ -1509,6 +1509,7 @@ SavePage.setPublicGdrive = function(fileId, authToken) {
 * @param  up     A boolean describing whether we're recursively ascending or descending the file tree (true for ascending)
 */
 SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
+
   // Get read-only OAuth permissions to view the users GDrive folders
   var authDetails = {'interactive': true, 'scopes': ['https://www.googleapis.com/auth/drive.readonly']};
   var recentParent = parentChain[parentChain.length - 1];
@@ -1532,6 +1533,9 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
       // Once we're given permission, populate the folder select dropdown
       success: function(response){
         var options = $("#gdrive-folder-select");
+
+        // Clear the list of folders
+        options.empty();
 
         // Add an option to go up a level in the folder tree,
         // as long we're currently not in the absolute root
@@ -1565,9 +1569,6 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
           // Folder traversing is only done if the selected folder isn't a "root"
           if (!options.children("option:selected").hasClass("no-recursion")){
 
-            // Clear the list of folders
-            options.empty();
-
             // If we're going up a folder, we should remove latestParent from the parentChain
             if (up){
               parentChain.pop();
@@ -1577,10 +1578,14 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
               parentChain.push(currentFolder);
             }
 
+            // Reset the save folder preference, since active folder is changing
+            SavePage.saveGDriveFolderPref(false);
             SavePage.getGDriveFolders({name: selectedFolderName, id: selectedFolderID}, parentChain, up);
           }
         });
 
+        // Preserve the save folder preference
+        SavePage.saveGDriveFolderPref(JSON.parse(localStorage.getItem("folderPref")).remember);
       },
 
       // For error handling
@@ -1593,6 +1598,22 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
     });
   });
 };
+
+/**
+* Saves the currently selected GDrive folder so that it is loaded
+* automatically the next time the users takes a screenshot. The folder is saved in
+* a key value pair {title: Folder-Name, id: Folder-ID}.
+* @author joshkayani@gmail.com
+*/
+SavePage.saveGDriveFolderPref = function(shouldRemember) {
+	var folName = $("#gdrive-folder-select").find(":selected").text();
+	var folID = $("#gdrive-folder-select").val();
+  console.log("Storing " + folName + " | " + folID);
+  localStorage.setItem("folderPref",
+    JSON.stringify({remember: shouldRemember, data: {name: folName, id: folID}})
+  );
+  $("input#save-gdrive-folder-pref").prop("checked", shouldRemember);
+}
 
 SavePage.saveToGdrive = function() {
   var imageName = $("#gdrive-image-name").val();
@@ -1833,12 +1854,29 @@ SavePage.initSaveOption = function(){
     $("#saveOptionContent").find(".sgdrive").addClass("selected");
     $("#saveOptionHead, #saveOptionBody").addClass("showContent");
     $("#saveLocal").hide();
-    // Populate the list of folders.
+
     $("#gdrive-folder-select").empty();
-    SavePage.getGDriveFolders(
-        {name: "My Drive", id: "root"},
-        [{name: "My Drive", id: "root"}],
-        false);
+
+  	// If the user opted to remember the last folder used,
+  	// load that instead of the root (My Drive).
+  	if (JSON.parse(localStorage.getItem("folderPref")).remember) {
+      var data = JSON.parse(localStorage.getItem("folderPref")).data;
+  		SavePage.getGDriveFolders(
+  			data,
+  			[{name: "My Drive", id: "root"}],
+  			false);
+  	}	else {
+  		SavePage.getGDriveFolders(
+  			{name: "My Drive", id: "root"},
+  			[{name: "My Drive", id: "root"}],
+  			false);
+	  }
+  });
+
+  // Change the user's preference to save the folder when the
+  // checkbox is checked/unchecked
+  $("input#save-gdrive-folder-pref").change(function() {
+    SavePage.saveGDriveFolderPref($(this).is(":checked"));
   });
 
   $("#gdrive-signout").click(function(a){


### PR DESCRIPTION
Hey:

This is in response to #18. The feature adds a checkbox that, when checked, saves the currently selected GDrive folder (name and ID pair) to a localStorage key. When a screenshot is taken later, and the user opts to save it in GDrive, the saved folder is automatically loaded into the dropdown (instead of the default "My Drive"). When the selected folder is changed, the checkbox is unchecked, and the user must re-check the box to save the newly selected folder for next time. 

Please take a look and consider merging this feature; I'll make any required style changes should there be any. 
