### PR TITLE
Fix for save local using HTML5

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -121,6 +121,9 @@
                     <br />
                     <!-- Folder select -->
                     <select id="gdrive-folder-select"></select>
+					          <br />
+					          <input type="checkbox" id="save-gdrive-folder-pref"><label for="gdrive-folder-pref">Remember this folder?</label>
+                    <br />
                     <br />
                     <span id="gdrive-save-button" class="button save">Save</span>
                   </div>
@@ -130,6 +133,9 @@
                     <input type="checkbox" id="gdrive-short-link"><label for="gdrive-short-link">Short link</label>
                   </div>
                   <div id="gdrive-user">
+                    <br />
+                    <br />
+                    <br />
                     <p>Account: <span></span></p>
                   </div>
                   <div id="notice">

--- a/edit.html
+++ b/edit.html
@@ -121,9 +121,6 @@
                     <br />
                     <!-- Folder select -->
                     <select id="gdrive-folder-select"></select>
-					          <br />
-					          <input type="checkbox" id="save-gdrive-folder-pref"><label for="gdrive-folder-pref">Remember this folder?</label>
-                    <br />
                     <br />
                     <span id="gdrive-save-button" class="button save">Save</span>
                   </div>
@@ -133,9 +130,6 @@
                     <input type="checkbox" id="gdrive-short-link"><label for="gdrive-short-link">Short link</label>
                   </div>
                   <div id="gdrive-user">
-                    <br />
-                    <br />
-                    <br />
                     <p>Account: <span></span></p>
                   </div>
                   <div id="notice">

--- a/edit.html
+++ b/edit.html
@@ -182,7 +182,7 @@
             </div>
             <div id="saveLocal" class="section">
               <h3><span class="title">Save Local</span></h3>
-              <div class="content clear save_button"><span>Save image as a file</span> <span class="button save"><a style="color:black;" id="save-html5-btn">Save</a></span></div>
+              <div class="content clear save_button"><span>Save image as a file</span> <span class="button save">Save<div id="save-flash-btn"></div></span></div>
               <div class="content clear copy_button"><span>Copy to clipboard</span> <span class="button save">Copy</span></div>
               <div class="content clear"><span>Print the screenshot</span> <span class="button save print_button">Print</span></div>
               <div class="content clear" style="color: #CBCBCB"><p>Check <a href="#" id="w-cpy" style="color: #ffffff;text-decoration: underline">why "Copy" Button was disabled, then enabled again</a>.</p></div>

--- a/edit.html
+++ b/edit.html
@@ -176,7 +176,7 @@
             </div>
             <div id="saveLocal" class="section">
               <h3><span class="title">Save Local</span></h3>
-              <div class="content clear save_button"><span>Save image as a file</span> <span class="button save">Save<div id="save-flash-btn"></div></span></div>
+              <div class="content clear save_button"><span>Save image as a file</span> <span class="button save"><a style="color:black;" id="save-html5-btn">Save<div id="save-flash-btn"></div></a></span></div>
               <div class="content clear copy_button"><span>Copy to clipboard</span> <span class="button save">Copy</span></div>
               <div class="content clear"><span>Print the screenshot</span> <span class="button save print_button">Print</span></div>
               <div class="content clear" style="color: #CBCBCB"><p>Check <a href="#" id="w-cpy" style="color: #ffffff;text-decoration: underline">why "Copy" Button was disabled, then enabled again</a>.</p></div>

--- a/edit.html
+++ b/edit.html
@@ -182,7 +182,7 @@
             </div>
             <div id="saveLocal" class="section">
               <h3><span class="title">Save Local</span></h3>
-              <div class="content clear save_button"><span>Save image as a file</span> <span class="button save">Save<div id="save-flash-btn"></div></span></div>
+              <div class="content clear save_button"><span>Save image as a file</span> <span class="button save"><a style="color:black;" id="save-html5-btn">Save</a></span></div>
               <div class="content clear copy_button"><span>Copy to clipboard</span> <span class="button save">Copy</span></div>
               <div class="content clear"><span>Print the screenshot</span> <span class="button save print_button">Print</span></div>
               <div class="content clear" style="color: #CBCBCB"><p>Check <a href="#" id="w-cpy" style="color: #ffffff;text-decoration: underline">why "Copy" Button was disabled, then enabled again</a>.</p></div>

--- a/javascripts/bg.js
+++ b/javascripts/bg.js
@@ -105,7 +105,7 @@ function captureDesktop(ctx) {
       function(streamId) {
         if (!streamId) return;  // User canceled.
         navigator.webkitGetUserMedia(
-            { audio: false,
+            { audio: false, 
               video: {
                 mandatory: {
                   chromeMediaSource: 'desktop',
@@ -195,11 +195,6 @@ localStorage.format || (localStorage.format = "png");
 localStorage.delay_sec || (localStorage.delay_sec = 3);
 localStorage.tip_touch_shown || (localStorage.tip_touch_shown = 0);
 
-// Set the default value for GDrive folder remembering
-localStorage.folderPref ||
-localStorage.setItem("folderPref",
-  JSON.stringify({remember: false, data: {}}));
-
 // Clean up old junk from localStorage.
 localStorage.removeItem("data-tracking");
 localStorage.removeItem("autoSave");
@@ -232,7 +227,7 @@ function handleRequest(ctx, req, sender) {
     testImage.src = "";
     setContextForTab([ctx.windowId, ctx.tabId], null);  // Disconnect from original tab.
   };
-
+  
   switch (req.action){
     case "visible": {
       if ("selected" == ctx.userAction) {

--- a/javascripts/bg.js
+++ b/javascripts/bg.js
@@ -105,7 +105,7 @@ function captureDesktop(ctx) {
       function(streamId) {
         if (!streamId) return;  // User canceled.
         navigator.webkitGetUserMedia(
-            { audio: false, 
+            { audio: false,
               video: {
                 mandatory: {
                   chromeMediaSource: 'desktop',
@@ -195,6 +195,11 @@ localStorage.format || (localStorage.format = "png");
 localStorage.delay_sec || (localStorage.delay_sec = 3);
 localStorage.tip_touch_shown || (localStorage.tip_touch_shown = 0);
 
+// Set the default value for GDrive folder remembering
+localStorage.folderPref ||
+localStorage.setItem("folderPref",
+  JSON.stringify({remember: false, data: {}}));
+
 // Clean up old junk from localStorage.
 localStorage.removeItem("data-tracking");
 localStorage.removeItem("autoSave");
@@ -227,7 +232,7 @@ function handleRequest(ctx, req, sender) {
     testImage.src = "";
     setContextForTab([ctx.windowId, ctx.tabId], null);  // Disconnect from original tab.
   };
-  
+
   switch (req.action){
     case "visible": {
       if ("selected" == ctx.userAction) {

--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -97,9 +97,9 @@ function prepareEditArea(req) {
         imageHeight = editH;
         showCtx.drawImage(
             this,
-            centerOffX * getDevicePixelRatio(),
-            centerOffY * getDevicePixelRatio(),
-            imageWidth * getDevicePixelRatio(),
+            centerOffX * getDevicePixelRatio(), 
+            centerOffY * getDevicePixelRatio(), 
+            imageWidth * getDevicePixelRatio(), 
             imageHeight * getDevicePixelRatio(),
             0, 0,
             imageWidth, imageHeight
@@ -127,8 +127,8 @@ function prepareEditArea(req) {
         } else {
           editW = imageWidth / getDevicePixelRatio();
         }
-        editH = lastH ?
-                    (imageHeight / getDevicePixelRatio()) * (numTilesY - 1) + (lastH / getDevicePixelRatio()) :
+        editH = lastH ? 
+                    (imageHeight / getDevicePixelRatio()) * (numTilesY - 1) + (lastH / getDevicePixelRatio()) : 
                     (imageHeight / getDevicePixelRatio()) * (numTilesY - 1);
         updateEditArea();
         updateShowCanvas();
@@ -1509,7 +1509,6 @@ SavePage.setPublicGdrive = function(fileId, authToken) {
 * @param  up     A boolean describing whether we're recursively ascending or descending the file tree (true for ascending)
 */
 SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
-
   // Get read-only OAuth permissions to view the users GDrive folders
   var authDetails = {'interactive': true, 'scopes': ['https://www.googleapis.com/auth/drive.readonly']};
   var recentParent = parentChain[parentChain.length - 1];
@@ -1533,9 +1532,6 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
       // Once we're given permission, populate the folder select dropdown
       success: function(response){
         var options = $("#gdrive-folder-select");
-
-        // Clear the list of folders
-        options.empty();
 
         // Add an option to go up a level in the folder tree,
         // as long we're currently not in the absolute root
@@ -1569,6 +1565,9 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
           // Folder traversing is only done if the selected folder isn't a "root"
           if (!options.children("option:selected").hasClass("no-recursion")){
 
+            // Clear the list of folders
+            options.empty();
+
             // If we're going up a folder, we should remove latestParent from the parentChain
             if (up){
               parentChain.pop();
@@ -1578,14 +1577,10 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
               parentChain.push(currentFolder);
             }
 
-            // Reset the save folder preference, since active folder is changing
-            SavePage.saveGDriveFolderPref(false);
             SavePage.getGDriveFolders({name: selectedFolderName, id: selectedFolderID}, parentChain, up);
           }
         });
 
-        // Preserve the save folder preference
-        SavePage.saveGDriveFolderPref(JSON.parse(localStorage.getItem("folderPref")).remember);
       },
 
       // For error handling
@@ -1598,22 +1593,6 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
     });
   });
 };
-
-/**
-* Saves the currently selected GDrive folder so that it is loaded
-* automatically the next time the users takes a screenshot. The folder is saved in
-* a key value pair {title: Folder-Name, id: Folder-ID}.
-* @author joshkayani@gmail.com
-*/
-SavePage.saveGDriveFolderPref = function(shouldRemember) {
-	var folName = $("#gdrive-folder-select").find(":selected").text();
-	var folID = $("#gdrive-folder-select").val();
-  console.log("Storing " + folName + " | " + folID);
-  localStorage.setItem("folderPref",
-    JSON.stringify({remember: shouldRemember, data: {name: folName, id: folID}})
-  );
-  $("input#save-gdrive-folder-pref").prop("checked", shouldRemember);
-}
 
 SavePage.saveToGdrive = function() {
   var imageName = $("#gdrive-image-name").val();
@@ -1854,29 +1833,12 @@ SavePage.initSaveOption = function(){
     $("#saveOptionContent").find(".sgdrive").addClass("selected");
     $("#saveOptionHead, #saveOptionBody").addClass("showContent");
     $("#saveLocal").hide();
-
+    // Populate the list of folders.
     $("#gdrive-folder-select").empty();
-
-  	// If the user opted to remember the last folder used,
-  	// load that instead of the root (My Drive).
-  	if (JSON.parse(localStorage.getItem("folderPref")).remember) {
-      var data = JSON.parse(localStorage.getItem("folderPref")).data;
-  		SavePage.getGDriveFolders(
-  			data,
-  			[{name: "My Drive", id: "root"}],
-  			false);
-  	}	else {
-  		SavePage.getGDriveFolders(
-  			{name: "My Drive", id: "root"},
-  			[{name: "My Drive", id: "root"}],
-  			false);
-	  }
-  });
-
-  // Change the user's preference to save the folder when the
-  // checkbox is checked/unchecked
-  $("input#save-gdrive-folder-pref").change(function() {
-    SavePage.saveGDriveFolderPref($(this).is(":checked"));
+    SavePage.getGDriveFolders(
+        {name: "My Drive", id: "root"},
+        [{name: "My Drive", id: "root"}],
+        false);
   });
 
   $("#gdrive-signout").click(function(a){

--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -495,10 +495,20 @@ function save() {
     var d = $("#save-image").attr("src").split(",")[1].replace(/\+/g,"%2b");
     e = tabtitle.replace(/[#$~!@%^&*();'"?><\[\]{}\|,:\/=+-]/g, " ");
     f = $("#save-image").attr("src").split(",")[0].split("/")[1].split(";")[0];
-
-    // Uses HTML5 Download attribute so we can stop using Flash
-    $("a#save-html5-btn").attr("href", $("img#save-image").attr("src"));
-    $("a#save-html5-btn").attr("download", "screenshot");
+    $("#save-flash-btn").empty().append('<div id="flash-save"></div>');
+    var g = "10", h = null;
+    var i = {data:d,dataType:"base64",filename:e+"."+f,width:100,height:30};
+    var j = {allowScriptAccess:"always"};
+    var k = {};
+    k.id = "CreateSaveWindow";
+    k.name = "CreateSaveWindow";
+    k.align = "middle";
+    swfobject.embedSWF("media/CreateSaveWindow.swf","flash-save","100","30",g,h,i,j,k);
+    chrome.extension.sendRequest({
+      action: "return_image_data",
+      data: c.replace(/^data:image\/(png|jpeg);base64,/,""),
+      title: tabtitle.replace(/[#$~!@%^&*();'"?><\[\]{}\|,:\/=+-]/g," ")
+    });
   }
 
   function onUploadClicked() {

--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -498,7 +498,7 @@ function save() {
 
     // Uses HTML5 Download attribute so we can stop using Flash
     $("a#save-html5-btn").attr("href", $("img#save-image").attr("src"));
-    $("a#save-html5-btn").attr("download", "screenshot");
+    $("a#save-html5-btn").attr("download", tabtitle);
   }
 
   function onUploadClicked() {

--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -97,9 +97,9 @@ function prepareEditArea(req) {
         imageHeight = editH;
         showCtx.drawImage(
             this,
-            centerOffX * getDevicePixelRatio(), 
-            centerOffY * getDevicePixelRatio(), 
-            imageWidth * getDevicePixelRatio(), 
+            centerOffX * getDevicePixelRatio(),
+            centerOffY * getDevicePixelRatio(),
+            imageWidth * getDevicePixelRatio(),
             imageHeight * getDevicePixelRatio(),
             0, 0,
             imageWidth, imageHeight
@@ -127,8 +127,8 @@ function prepareEditArea(req) {
         } else {
           editW = imageWidth / getDevicePixelRatio();
         }
-        editH = lastH ? 
-                    (imageHeight / getDevicePixelRatio()) * (numTilesY - 1) + (lastH / getDevicePixelRatio()) : 
+        editH = lastH ?
+                    (imageHeight / getDevicePixelRatio()) * (numTilesY - 1) + (lastH / getDevicePixelRatio()) :
                     (imageHeight / getDevicePixelRatio()) * (numTilesY - 1);
         updateEditArea();
         updateShowCanvas();
@@ -1509,6 +1509,7 @@ SavePage.setPublicGdrive = function(fileId, authToken) {
 * @param  up     A boolean describing whether we're recursively ascending or descending the file tree (true for ascending)
 */
 SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
+
   // Get read-only OAuth permissions to view the users GDrive folders
   var authDetails = {'interactive': true, 'scopes': ['https://www.googleapis.com/auth/drive.readonly']};
   var recentParent = parentChain[parentChain.length - 1];
@@ -1532,6 +1533,9 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
       // Once we're given permission, populate the folder select dropdown
       success: function(response){
         var options = $("#gdrive-folder-select");
+
+        // Clear the list of folders
+        options.empty();
 
         // Add an option to go up a level in the folder tree,
         // as long we're currently not in the absolute root
@@ -1565,9 +1569,6 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
           // Folder traversing is only done if the selected folder isn't a "root"
           if (!options.children("option:selected").hasClass("no-recursion")){
 
-            // Clear the list of folders
-            options.empty();
-
             // If we're going up a folder, we should remove latestParent from the parentChain
             if (up){
               parentChain.pop();
@@ -1577,10 +1578,14 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
               parentChain.push(currentFolder);
             }
 
+            // Reset the save folder preference, since active folder is changing
+            SavePage.saveGDriveFolderPref(false);
             SavePage.getGDriveFolders({name: selectedFolderName, id: selectedFolderID}, parentChain, up);
           }
         });
 
+        // Preserve the save folder preference
+        SavePage.saveGDriveFolderPref(JSON.parse(localStorage.getItem("folderPref")).remember);
       },
 
       // For error handling
@@ -1593,6 +1598,22 @@ SavePage.getGDriveFolders = function(currentFolder, parentChain, up){
     });
   });
 };
+
+/**
+* Saves the currently selected GDrive folder so that it is loaded
+* automatically the next time the users takes a screenshot. The folder is saved in
+* a key value pair {title: Folder-Name, id: Folder-ID}.
+* @author joshkayani@gmail.com
+*/
+SavePage.saveGDriveFolderPref = function(shouldRemember) {
+	var folName = $("#gdrive-folder-select").find(":selected").text();
+	var folID = $("#gdrive-folder-select").val();
+  console.log("Storing " + folName + " | " + folID);
+  localStorage.setItem("folderPref",
+    JSON.stringify({remember: shouldRemember, data: {name: folName, id: folID}})
+  );
+  $("input#save-gdrive-folder-pref").prop("checked", shouldRemember);
+}
 
 SavePage.saveToGdrive = function() {
   var imageName = $("#gdrive-image-name").val();
@@ -1833,12 +1854,29 @@ SavePage.initSaveOption = function(){
     $("#saveOptionContent").find(".sgdrive").addClass("selected");
     $("#saveOptionHead, #saveOptionBody").addClass("showContent");
     $("#saveLocal").hide();
-    // Populate the list of folders.
+
     $("#gdrive-folder-select").empty();
-    SavePage.getGDriveFolders(
-        {name: "My Drive", id: "root"},
-        [{name: "My Drive", id: "root"}],
-        false);
+
+  	// If the user opted to remember the last folder used,
+  	// load that instead of the root (My Drive).
+  	if (JSON.parse(localStorage.getItem("folderPref")).remember) {
+      var data = JSON.parse(localStorage.getItem("folderPref")).data;
+  		SavePage.getGDriveFolders(
+  			data,
+  			[{name: "My Drive", id: "root"}],
+  			false);
+  	}	else {
+  		SavePage.getGDriveFolders(
+  			{name: "My Drive", id: "root"},
+  			[{name: "My Drive", id: "root"}],
+  			false);
+	  }
+  });
+
+  // Change the user's preference to save the folder when the
+  // checkbox is checked/unchecked
+  $("input#save-gdrive-folder-pref").change(function() {
+    SavePage.saveGDriveFolderPref($(this).is(":checked"));
   });
 
   $("#gdrive-signout").click(function(a){

--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -498,7 +498,7 @@ function save() {
 
     // Uses HTML5 Download attribute so we can stop using Flash
     $("a#save-html5-btn").attr("href", $("img#save-image").attr("src"));
-    $("a#save-html5-btn").attr("download", tabtitle);
+    $("a#save-html5-btn").attr("download", "screenshot");
   }
 
   function onUploadClicked() {

--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -495,20 +495,10 @@ function save() {
     var d = $("#save-image").attr("src").split(",")[1].replace(/\+/g,"%2b");
     e = tabtitle.replace(/[#$~!@%^&*();'"?><\[\]{}\|,:\/=+-]/g, " ");
     f = $("#save-image").attr("src").split(",")[0].split("/")[1].split(";")[0];
-    $("#save-flash-btn").empty().append('<div id="flash-save"></div>');
-    var g = "10", h = null;
-    var i = {data:d,dataType:"base64",filename:e+"."+f,width:100,height:30};
-    var j = {allowScriptAccess:"always"};
-    var k = {};
-    k.id = "CreateSaveWindow";
-    k.name = "CreateSaveWindow";
-    k.align = "middle";
-    swfobject.embedSWF("media/CreateSaveWindow.swf","flash-save","100","30",g,h,i,j,k);
-    chrome.extension.sendRequest({
-      action: "return_image_data",
-      data: c.replace(/^data:image\/(png|jpeg);base64,/,""),
-      title: tabtitle.replace(/[#$~!@%^&*();'"?><\[\]{}\|,:\/=+-]/g," ")
-    });
+
+    // Uses HTML5 Download attribute so we can stop using Flash
+    $("a#save-html5-btn").attr("href", $("img#save-image").attr("src"));
+    $("a#save-html5-btn").attr("download", "screenshot");
   }
 
   function onUploadClicked() {

--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -97,9 +97,9 @@ function prepareEditArea(req) {
         imageHeight = editH;
         showCtx.drawImage(
             this,
-            centerOffX * getDevicePixelRatio(), 
-            centerOffY * getDevicePixelRatio(), 
-            imageWidth * getDevicePixelRatio(), 
+            centerOffX * getDevicePixelRatio(),
+            centerOffY * getDevicePixelRatio(),
+            imageWidth * getDevicePixelRatio(),
             imageHeight * getDevicePixelRatio(),
             0, 0,
             imageWidth, imageHeight
@@ -127,8 +127,8 @@ function prepareEditArea(req) {
         } else {
           editW = imageWidth / getDevicePixelRatio();
         }
-        editH = lastH ? 
-                    (imageHeight / getDevicePixelRatio()) * (numTilesY - 1) + (lastH / getDevicePixelRatio()) : 
+        editH = lastH ?
+                    (imageHeight / getDevicePixelRatio()) * (numTilesY - 1) + (lastH / getDevicePixelRatio()) :
                     (imageHeight / getDevicePixelRatio()) * (numTilesY - 1);
         updateEditArea();
         updateShowCanvas();
@@ -495,6 +495,13 @@ function save() {
     var d = $("#save-image").attr("src").split(",")[1].replace(/\+/g,"%2b");
     e = tabtitle.replace(/[#$~!@%^&*();'"?><\[\]{}\|,:\/=+-]/g, " ");
     f = $("#save-image").attr("src").split(",")[0].split("/")[1].split(";")[0];
+
+    // Uses HTML5 Download attribute so we can stop using Flash
+    $("a#save-html5-btn").attr("href", $("img#save-image").attr("src"));
+    $("a#save-html5-btn").attr("download", tabtitle);
+
+    /*
+    // Old Flash Code
     $("#save-flash-btn").empty().append('<div id="flash-save"></div>');
     var g = "10", h = null;
     var i = {data:d,dataType:"base64",filename:e+"."+f,width:100,height:30};
@@ -509,6 +516,7 @@ function save() {
       data: c.replace(/^data:image\/(png|jpeg);base64,/,""),
       title: tabtitle.replace(/[#$~!@%^&*();'"?><\[\]{}\|,:\/=+-]/g," ")
     });
+    */
   }
 
   function onUploadClicked() {


### PR DESCRIPTION
This is in response to #13. The feature recreates the functionality of the "Save" button without using Flash; instead, this uses the HTML5 Download API, turning the Save button into a link to the created image that prompts a download. 

The old Flash code has been commented out, and I'm pretty sure the actual `.swf` file is still in a folder somewhere. I'll make any required style changes should there be any. 
