### PR TITLE
Fix entire page capture 

### DIFF
--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -2,8 +2,11 @@ function getDevicePixelRatio() {
     return window.devicePixelRatio || 1;
 }
 function prepareEditArea(req) {
+
+  /* https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage */
   function addTileY(imgSrc, sx, sy, sw, sh, dx, dy, dw, dh){
     dy = counterY * (imageHeight / getDevicePixelRatio());
+    dx = counterX * (imageWidth / getDevicePixelRatio());
     if (counterY == numTilesY - 1) {
       sy = imageHeight - lastH;
       dh = (lastH / getDevicePixelRatio());
@@ -21,7 +24,7 @@ function prepareEditArea(req) {
     });
   }
   function addTileX(imgSrc, sx, sy, sw, sh, dx, dy, dw, dh){
-    dx = counterX * imageWidth;
+    dx = counterX * (imageWidth / getDevicePixelRatio());
     if (counterX == numTilesX - 1) {
       sx = imageWidth - lastW;
       sw = dw = lastW;
@@ -136,7 +139,7 @@ function prepareEditArea(req) {
         addMargin();
         getEditOffset();
         var sourceWidth = imageWidth * getDevicePixelRatio();
-		var sourceHeight = imageHeight * getDevicePixelRatio();
+		    var sourceHeight = imageHeight * getDevicePixelRatio();
         addTileY(images[0], centerOffX, centerOffY, sourceWidth, sourceHeight, 0, 0, imageWidth, imageHeight);
       } else if (scrollBar.x && !scrollBar.y) {
         imageHeight -= scrollbarWidth;

--- a/javascripts/edit.js
+++ b/javascripts/edit.js
@@ -43,11 +43,11 @@ function prepareEditArea(req) {
       var columnOffsetX, columnWidth;
       if (counterX == numTilesX - 1) {
         centerOffX = imageWidth - lastW;
-        columnWidth = editW - counterX * imageWidth;
+        columnWidth = (editW - counterX * imageWidth) / getDevicePixelRatio();
         columnOffsetX = counterX * imageWidth;
       } else {
         centerOffX = 0;
-        columnWidth = imageWidth;
+        columnWidth = imageWidth / getDevicePixelRatio();
         columnOffsetX = counterX * imageWidth;
       }
       centerOffY = 0;
@@ -149,7 +149,7 @@ function prepareEditArea(req) {
           if (scrollBar.realY) imageWidth -= scrollbarWidth;
           editH = req.centerH * getDevicePixelRatio();
         } else {
-          editH = imageHeight;
+          editH = imageHeight / getDevicePixelRatio();
         }
         editW = lastW ? imageWidth * (numTilesX - 1) + lastW : imageWidth * numTilesX;
         updateEditArea();


### PR DESCRIPTION
This PR fixes #44 and restores entire page capture functionality. 

This was broken because the extension wasn't properly causing the browser to scroll (`document.body.scroll*` instead of `document.documentElement.scroll*`), so that it could take captures all the way down the page.

The edit page was also incorrectly placing captures tiled along the x-axis b/c it was ignoring the device pixel ratio. 

In summary, I changed the `scrollNext()` function to properly scroll along the page, and some of the rendering code in `edit.js` to properly layout the captures into 1 image. 

Let me know if anything looks incorrect, or needs to be cleaned up. 